### PR TITLE
add inverse sqrt root scheduler

### DIFF
--- a/experiments/mnist/conf/mnist.yaml
+++ b/experiments/mnist/conf/mnist.yaml
@@ -5,7 +5,7 @@ trainer:
     accelerator: gpu
     max_epochs: -1
     accumulate_grad_batches: 16
-    strategy: ddp
+    strategy: auto
 
 datamodule:
     _target_: tinyedm.datamodule.MNISTDataModule
@@ -41,6 +41,9 @@ denoiser:
 model:
     use_uncertainty: True
     lr: 0.0001
+    alpha_ref: 0.01
+    t_ref: 1000
+
 
 solver:
     _target_: tinyedm.DeterministicSolver

--- a/src/tinyedm/edm.py
+++ b/src/tinyedm/edm.py
@@ -118,6 +118,7 @@ class EDM(L.LightningModule):
             loss = self.mse(weight, denoised_image, clean_image)
 
         self.log("train_loss", self.mse, prog_bar=True, on_epoch=True, on_step=True)
+        self.log("learning_rate", self.lr_schedulers().get_last_lr()[0], prog_bar=False, on_epoch=True, on_step=False)
         return loss
 
     def configure_optimizers(self):


### PR DESCRIPTION
We now have fully implemented all models in EDM v2, except for Post-hoc EMA.