### PR TITLE
Initialize gain to be 1 in encoder/decoder blocks

### DIFF
--- a/experiments/mnist/conf/mnist.yaml
+++ b/experiments/mnist/conf/mnist.yaml
@@ -72,7 +72,7 @@ wandb:
     resume: True
     reinit: False
 
-watch_watch:
+wandb_watch:
     log_freq: 500
     log: all
 

--- a/src/tinyedm/networks.py
+++ b/src/tinyedm/networks.py
@@ -218,7 +218,7 @@ class EncoderBlock(nn.Module):
 
         # embedding layer
         self.embed = Linear(embedding_dim, out_channels)
-        self.gain = nn.Parameter(torch.zeros(1))
+        self.gain = nn.Parameter(torch.ones(1))
 
     def forward(self, input: Tensor, embedding: Tensor) -> Tensor:
         x = self.resample(input)
@@ -277,7 +277,7 @@ class DecoderBlock(nn.Module):
 
         # embedding layer
         self.embed = Linear(embedding_dim, out_channels)
-        self.gain = nn.Parameter(torch.zeros(1))
+        self.gain = nn.Parameter(torch.ones(1))
 
     def forward(
         self, input: Tensor, embedding: Tensor, skip: Tensor | None = None


### PR DESCRIPTION
This PR introduces a subtle difference from the original paper, I initialize the gain inside the EncoderBlock and Decoder Block to 1, I think it is correct to do so.